### PR TITLE
UI修正＋タイポ修正

### DIFF
--- a/apps/frontend/src/components/ChatMessages.tsx
+++ b/apps/frontend/src/components/ChatMessages.tsx
@@ -16,11 +16,21 @@ const ChatMessages: React.FC<ChatMessagesProps> = ({ messages }) => {
   }, [messages]);
 
   return (
-    <div className="flex-1 overflow-y-auto bg-gray-800 text-white p-4">
+    <div className="flex-1 overflow-y-auto bg-gray-800 text-white p-8">
       {messages.map((msg, index) => (
-        <p key={index} className="mb-4">
-          <strong>{msg.sender}:</strong> {msg.message}
-        </p>
+        <div key={index} className={`mb-4 ${msg.sender === 'You' ? 'text-right' : 'text-left'}`}>
+          {/* sender */}
+          <div>
+            <strong>{msg.sender}</strong>
+          </div>
+
+          {/* message */}
+          <div
+            className={`p-2 rounded-xl whitespace-pre-wrap inline-block ${msg.sender === 'You' ? 'bg-brandColor' : 'bg-gray-700'}`}
+          >
+            {msg.message}
+          </div>
+        </div>
       ))}
       <div ref={messagesEndRef} />
     </div>

--- a/apps/frontend/src/components/GamePage.tsx
+++ b/apps/frontend/src/components/GamePage.tsx
@@ -2,14 +2,12 @@ import React from 'react';
 
 import Game from './Game';
 import Header from './Header';
-import SideBar from './SideBar';
 
 const GamePage: React.FC = () => {
   return (
     <div className="flex flex-col h-screen">
       <Header />
       <div className="flex flex-1 overflow-hidden">
-        <SideBar />
         <Game />
       </div>
     </div>

--- a/apps/frontend/src/utils/types/WSMessage.ts
+++ b/apps/frontend/src/utils/types/WSMessage.ts
@@ -18,12 +18,10 @@ export interface MessageChat {
 
 /**
  * 結果メッセージの型定義
- *
- * TODO: failedが正(要API側修正)
  */
 export interface MessageResult {
   message_type: 'result';
-  result: 'success' | 'faild';
+  result: 'success' | 'failed';
   sender: string;
 }
 


### PR DESCRIPTION
- サイドバーの削除(component配下には残す)
- 改行も表示されるように(Botからの返信)
- 自身のチャットは右寄せになるように
- チャットごとに背景色をつけるように(自身のチャットは青色に)

| 新旧 | 画像 | 
| :---- | :----: | 
| 旧 | <img width="869" alt="image" src="https://github.com/user-attachments/assets/1eca61c9-25f4-4b9a-a709-e72ecae934b8"> | 
| 新 | <img width="870" alt="image" src="https://github.com/user-attachments/assets/0b5c1480-d57f-4e70-bf61-44b155d1a769"> | 
