### PR TITLE
大文字小文字を修正

### DIFF
--- a/apps/frontend/src/components/ChatInput.tsx
+++ b/apps/frontend/src/components/ChatInput.tsx
@@ -140,7 +140,7 @@ const ChatInput: React.FC<ChatInputProps> = ({ isFirstRender, onStartGame, onSen
 
       <div className="flex items-center bg-gray-700 p-4">
         {isFirstRender ? (
-          <Button value="Click to Start" onClick={onStartGame} className="flex-1 bg-gray-600" />
+          <Button value="CLICK to START" onClick={onStartGame} className="flex-1 bg-gray-600" />
         ) : (
           <>
             {/* 切り替えボタン */}
@@ -156,7 +156,7 @@ const ChatInput: React.FC<ChatInputProps> = ({ isFirstRender, onStartGame, onSen
                 onCompositionStart={() => setIsComposing(true)}
                 onCompositionEnd={() => setIsComposing(false)}
                 className="flex-1 p-2 px-4 mx-2 rounded-full bg-gray-600 text-white"
-                placeholder="Type your Message"
+                placeholder="Type your message"
               />
             ) : (
               <div className="flex flex-1 mx-2 justify-center">


### PR DESCRIPTION
ゲームのタイトル画面のイメージでclickとstartを大文字に。
<img width="979" alt="image" src="https://github.com/user-attachments/assets/6a4402c4-4792-437b-a7b3-d23f765f9e33">
↓
<img width="977" alt="image" src="https://github.com/user-attachments/assets/47f5f0fc-e29a-42d9-a662-be50cb097da2">

プレースホルダは通常英文と同じで先頭だけ大文字に。
<img width="986" alt="image" src="https://github.com/user-attachments/assets/a296b00e-5207-4faa-9f5e-c4014080ffd5">
↓
<img width="979" alt="image" src="https://github.com/user-attachments/assets/ff4e9e56-1576-4501-a60f-32ef59cedf03">
